### PR TITLE
Create student hub import file

### DIFF
--- a/family.py
+++ b/family.py
@@ -80,30 +80,46 @@ class Family:
         self.children.append(new_child)
     
     def IsSameFamily(self, other):
-        if not len(self.adults) == len(other.adults):
-            return False
-        
-        num_found = 0
-        for adult in self.adults:
-            for other_adult in other.adults:
-                if adult.IsSame(other_adult):
-                    num_found += 1
-                    break
-        
-        return num_found == len(self.adults)
+        """Family.IsSameFamily
+        INPUTS:
+        - other -- the family object to compare to
+        OUTPUTS:
+        - returns True when the two objects contain all the same adults
+          or when the two objects share at least one adult and one child
+        - returns False otherwise
+        """
+        adults_found = 0
+        for other_adult in other.adults:
+            if self.FindAdultInFamily(other_adult) != None:
+                adults_found += 1
+
+        # if both families contain all the same adults
+        if adults_found == len(self.adults):
+            return True
+        # otherwise if the families share at least one adult and one child
+        elif adults_found > 0:
+            for other_child in other.children:
+                if self.FindChildInFamily(other_child) != None:
+                    return True
+
+        return False
 
     def HasNewChildren(self, other):
-        if not len(self.children) == len(other.children):
-            return False
-        
-        num_found = 0
+        """Family.HasNewChildren
+        INPUTS:
+        - other -- 
+        - other -- the family object to compare to
+        OUTPUTS:
+        - returns True if any child in the other family is not found in this family
+        - returns False otherwise
+        """
         for other_child in other.children:
-            for child in self.children:
-                if child.IsSame(other_child):
-                    num_found += 1
-                    break
-        
-        return num_found != len(self.children)
+            # if any child in the other family cannot be found in this family...
+            if self.FindChildInFamily(other_child) == None:
+                #... return True
+                return True
+
+        return False
 
     def FormFamilyWithNewChildren(self, directory_family, roster_family):
         # copy the adults from the directory, because they include the person_ids
@@ -111,18 +127,16 @@ class Family:
         
         # copy only the new children
         for roster_child in roster_family.children:
-            for directory_child in directory_family.children:
-                if roster_child.IsSame(directory_child):
-                    break
-            else:
+            # if the roster_child cannot be found in this family ...
+            if directory_family.FindChildInFamily(roster_child) == None:
+                # ...then append the roster_child to this family
                 self.children.append(roster_child)
 
     def CombineWith(self, other):
         for possible_child in other.children:
-            for existing_child in self.children:
-                if existing_child.IsSame(possible_child):
-                    break
-            else:
+            # if the possible_child cannot be found in this family...
+            if self.FindChildInFamily(possible_child) == None:
+                #...then append the possible_child to the family
                 self.children.append(possible_child)
                 # change the family relation for the new child
                 self.children[-1].family_relation = "Child%d" % (len(self.children))
@@ -136,15 +150,25 @@ class Family:
     def IsOrphan(self):
         return len(self.adults) == 0
 
-    def FindPersonInFamily(self, to_find):
+    def FindAdultInFamily(self, to_find):
         for adult in self.adults:
             if to_find.IsSame(adult):
                 return adult
+        return None
+
+    def FindChildInFamily(self, to_find):
         for child in self.children:
             if to_find.IsSame(child):
                 return child
         return None
-    
+        
+    def FindPersonInFamily(self, to_find):
+        try_person = self.FindAdultInFamily(to_find)
+        if try_person == None:
+            try_person = self.FindChildInFamily(to_find)
+
+        return try_person
+
     def Print(self):
         print "Adults:"
         for adult in self.adults:

--- a/family.py
+++ b/family.py
@@ -18,7 +18,13 @@ class Family:
     def AddAdultsFromCombinedField(self, teacher, name_field):
         parent_count = 1
         parent_num = ""
-        parents = name_field.split(" and ")
+        if name_field.find(" And ") > 0:
+            parents = name_field.split(" And ")
+        elif name_field.find(" & ") > 0:
+            parents = name_field.split(" & ")
+        else:
+            parents = name_field.split(" and ")
+
         # if parents have same last name, then there is only one name
         # before the first "and"
         if len(parents[0].split(" ")) == 1:

--- a/import_file_tools.py
+++ b/import_file_tools.py
@@ -13,8 +13,9 @@ def FormTimeTag():
     return tag
 
 def ConvertHubListToImportString(hub_list):
+    hub_str = "/"
     for hub in hub_list:
-        hub_str = str(hub) + ";"
+        hub_str += str(hub) + "/"
         
     return hub_str[:-1]  # strip off the trailing ';'
     

--- a/import_file_tools.py
+++ b/import_file_tools.py
@@ -17,7 +17,7 @@ def ConvertHubListToImportString(hub_list):
     for hub in hub_list:
         hub_str += str(hub) + "/"
         
-    return hub_str[:-1]  # strip off the trailing ';'
+    return hub_str  # strip off the trailing ';'
     
 def WriteNewMemberLine(open_file, family_relation, first_name, last_name, hubs, person_id):
     line = "%s,%s,%s,%s,%s\n" % (family_relation, first_name, last_name, hubs, person_id)

--- a/menu.py
+++ b/menu.py
@@ -229,7 +229,7 @@ def MakeStudentImportFile(arg_list):
     directory entries for people who are in the roster, but not already in the directory.
     Includes hub ID assignments for these people.
     ASSUMPTIONS:
-    None.
+    Each person in the roster belongs to only one hub, and it is the classroom hub.
     """
     directory = arg_list[0]
     roster    = arg_list[1]
@@ -249,13 +249,9 @@ def MakeStudentImportFile(arg_list):
                         ## instantiate a new Directory Person object, and copy the directory child into it
                         temp_child = person.DirectoryPerson()
                         temp_child = directory_child
-                        ## clear the temporary object's hubs
-                        temp_child.hubs = []
-                        ## populate the temporary object's hubs with the roster child's hubs
+                        ## populate the temporary object's hub with the roster child's hub
                         ## modified with the student indicator appended
-                        ## TBD - is student_hub a necessary step?
-                        student_hub = roster_child.hubs[0] + STUDENT_INDICATOR
-                        temp_child.hubs.append(student_hub)
+                        temp_child.hubs = [roster_child.hubs[0] + STUDENT_INDICATOR]
                         ## add the temporary child object to the list of students
                         students.append(temp_child)
                     else:

--- a/menu.py
+++ b/menu.py
@@ -10,7 +10,7 @@ import import_file_tools
 import family
 import person
 
-STUDENT_INDICATOR = "+SA/"
+STUDENT_INDICATOR = "+SA"
 
 def FindMissingEmail(directory):
     """menu.FindMissingEmail

--- a/menu.py
+++ b/menu.py
@@ -10,8 +10,7 @@ import import_file_tools
 import family
 import person
 
-### TBD - Need to confirm Student Indicator with Loren
-STUDENT_INDICATOR = "SA"
+STUDENT_INDICATOR = "+SA/"
 
 def FindMissingEmail(directory):
     """menu.FindMissingEmail
@@ -254,10 +253,9 @@ def MakeStudentImportFile(arg_list):
                         temp_child.hubs = []
                         ## populate the temporary object's hubs with the roster child's hubs
                         ## modified with the student indicator appended
-                        for hub in roster_child.hubs:
-                            ## TBD - is student_hub a necessary step?
-                            student_hub = hub + STUDENT_INDICATOR
-                            temp_child.hubs.append(student_hub)
+                        ## TBD - is student_hub a necessary step?
+                        student_hub = "/" + roster_child.hubs[0] + STUDENT_INDICATOR
+                        temp_child.hubs.append(student_hub)
                         ## add the temporary child object to the list of students
                         students.append(temp_child)
                     else:

--- a/menu.py
+++ b/menu.py
@@ -244,24 +244,27 @@ def MakeStudentImportFile(arg_list):
                 ## For each child in the roster family...
                 for roster_child in roster_family.children:
                     ## ...find the corresponding child in the directory family
-                    for directory_child in directory_family.children:
-                        if directory_child.IsSame(roster_child):
-                            ## instantiate a new Directory Person object, and copy the directory child into it
-                            temp_child = person.DirectoryPerson()
-                            temp_child = directory_child
-                            ## clear the temporary object's hubs
-                            temp_child.hubs = []
-                            ## populate the temporary object's hubs with the roster child's hubs
-                            ## modified with the student indicator appended
-                            for hub in roster_child.hubs:
-                                ## TBD - is student_hub a necessary step?
-                                student_hub = hub + STUDENT_INDICATOR
-                                temp_child.hubs.append(student_hub)
-                            ## add the temporary child object to the list of students
-                            students.append(temp_child)
+                    directory_child = directory_family.FindChildInFamily(roster_child)
+                    if directory_child != None:
+                        ## instantiate a new Directory Person object, and copy the directory child into it
+                        temp_child = person.DirectoryPerson()
+                        temp_child = directory_child
+                        ## clear the temporary object's hubs
+                        temp_child.hubs = []
+                        ## populate the temporary object's hubs with the roster child's hubs
+                        ## modified with the student indicator appended
+                        for hub in roster_child.hubs:
+                            ## TBD - is student_hub a necessary step?
+                            student_hub = hub + STUDENT_INDICATOR
+                            temp_child.hubs.append(student_hub)
+                        ## add the temporary child object to the list of students
+                        students.append(temp_child)
                     else:
-                        print "Did not find this child in the family:  ",
+                        print "##################"
+                        print "Did not find this child",
                         roster_child.Print()
+                        print " in the family: "
+                        directory_family.Print()
                 ## Found the roster family in the directory, so break out of the directory_family loop
                 break
         else:

--- a/menu.py
+++ b/menu.py
@@ -235,6 +235,7 @@ def MakeStudentImportFile(arg_list):
     directory = arg_list[0]
     roster    = arg_list[1]
     students  = []
+    not_found = []
 
     ## For each family in the roster ...
     for roster_family in roster:
@@ -265,13 +266,16 @@ def MakeStudentImportFile(arg_list):
                         roster_child.Print()
                         print " in the family: "
                         directory_family.Print()
+                        not_found.append(roster_child)
                 ## Found the roster family in the directory, so break out of the directory_family loop
                 break
         else:
             print "Did not find this family from the roster in the directory:",
             roster_family.Print()
+            not_found.append(roster_family.children)
 
     print "Found %d students on the roster who were in the directory" % len(students)
+    print "%d students on the roster could not be matched with the directory" % len(not_found)
 
     ## Create an import file with all the students
     import_file_tools.CreateHublessImportFile(students)

--- a/menu.py
+++ b/menu.py
@@ -11,7 +11,7 @@ import family
 import person
 
 ### TBD - Need to confirm Student Indicator with Loren
-constant STUDENT_INDICATOR = "SA"
+STUDENT_INDICATOR = "SA"
 
 def FindMissingEmail(directory):
     """menu.FindMissingEmail

--- a/menu.py
+++ b/menu.py
@@ -254,7 +254,7 @@ def MakeStudentImportFile(arg_list):
                         ## populate the temporary object's hubs with the roster child's hubs
                         ## modified with the student indicator appended
                         ## TBD - is student_hub a necessary step?
-                        student_hub = "/" + roster_child.hubs[0] + STUDENT_INDICATOR
+                        student_hub = roster_child.hubs[0] + STUDENT_INDICATOR
                         temp_child.hubs.append(student_hub)
                         ## add the temporary child object to the list of students
                         students.append(temp_child)

--- a/menu.py
+++ b/menu.py
@@ -236,17 +236,28 @@ def MakeStudentImportFile(arg_list):
     roster    = arg_list[1]
     students  = []
 
+    ## For each family in the roster ...
     for roster_family in roster:
+        ## ...find the corresponding family in the directory
         for directory_family in directory:
             if directory_family.IsSameFamily(roster_family):
+                ## For each child in the roster family...
                 for roster_child in roster_family.children:
+                    ## ...find the corresponding child in the directory family
                     for directory_child in directory_family.children:
                         if directory_child.IsSame(roster_child):
+                            ## instantiate a new Directory Person object, and copy the directory child into it
+                            temp_child = person.DirectoryPerson()
                             temp_child = directory_child
+                            ## clear the temporary object's hubs
                             temp_child.hubs = []
+                            ## populate the temporary object's hubs with the roster child's hubs
+                            ## modified with the student indicator appended
                             for hub in roster_child.hubs:
+                                ## TBD - is student_hub a necessary step?
                                 student_hub = hub + STUDENT_INDICATOR
                                 temp_child.hubs.append(student_hub)
+                            ## add the temporary child object to the list of students
                             students.append(temp_child)
                     else:
                         print "Did not find this child in the family:  ",
@@ -258,6 +269,9 @@ def MakeStudentImportFile(arg_list):
             roster_family.Print()
 
     print "Found %d students on the roster who were in the directory" % len(students)
+
+    ## Create an import file with all the students
+    import_file_tools.CreateHublessImportFile(students)
 
     
 def MakePrompt(choices):

--- a/menu.py
+++ b/menu.py
@@ -10,6 +10,9 @@ import import_file_tools
 import family
 import person
 
+### TBD - Need to confirm Student Indicator with Loren
+constant STUDENT_INDICATOR = "SA"
+
 def FindMissingEmail(directory):
     """menu.FindMissingEmail
     INPUTS:
@@ -217,6 +220,46 @@ def MakeImportNotInDirectory(arg_list):
 
     import_file_tools.CreateNewMemberImport(entriless)
 
+def MakeStudentImportFile(arg_list):
+    """menu.MakeStudentImportFile
+    INPUTS:
+    - directory -- dictionary containing the MemberHub directory
+    - roster    -- dictionary containing the school roster
+    OUTPUTS:
+    Creates a comma-separated text file that can be imported into MemberHub to create
+    directory entries for people who are in the roster, but not already in the directory.
+    Includes hub ID assignments for these people.
+    ASSUMPTIONS:
+    None.
+    """
+    directory = arg_list[0]
+    roster    = arg_list[1]
+    students  = []
+
+    for roster_family in roster:
+        for directory_family in directory:
+            if directory_family.IsSameFamily(roster_family):
+                for roster_child in roster_family.children:
+                    for directory_child in directory_family.children:
+                        if directory_child.IsSame(roster_child):
+                            temp_child = directory_child
+                            temp_child.hubs = []
+                            for hub in roster_child.hubs:
+                                student_hub = hub + STUDENT_INDICATOR
+                                temp_child.hubs.append(student_hub)
+                            students.append(temp_child)
+                    else:
+                        print "Did not find this child in the family:  ",
+                        roster_child.Print()
+                ## Found the roster family in the directory, so break out of the directory_family loop
+                break
+        else:
+            print "Did not find this family from the roster in the directory:",
+            roster_family.Print()
+
+    print "Found %d students on the roster who were in the directory" % len(students)
+
+    
 def MakePrompt(choices):
     choice_list = sorted(choices)
     guts = '\n'.join(['(%s)%s' % (choice[0], choice[1:])
@@ -239,7 +282,9 @@ def RunMenu(directory, roster, map_d):
                '6 - Find Not in Directory':
                     {'Function':PrintNotInDirectory,'Arg':[directory,roster]},
                '7 - Make Import File for Not In Directory':
-                    {'Function':MakeImportNotInDirectory,'Arg':[directory,roster,map_d]}}
+                    {'Function':MakeImportNotInDirectory,'Arg':[directory,roster,map_d]},
+               '8 - Make Student Hub Population Import File':
+                    {'Function':MakeStudentImportFile,'Arg':[directory,roster]}}
     
     prompt = MakePrompt(choices)
 


### PR DESCRIPTION
Added the ability to create a student import file:  a file that imports children to classroom hubs as students, and brings their adults along with them.  Had to fix logic in the Family class that compared families, and updated how the import file generator converts hub lists to strings to reflect the new standard.